### PR TITLE
lint: clear up most warnings and run cargo fmt

### DIFF
--- a/backend/_core/rust/src/google.rs
+++ b/backend/_core/rust/src/google.rs
@@ -1,12 +1,12 @@
 use futures_util::future::TryFutureExt;
+use jsonwebtoken as jwt;
 use serde::{Deserialize, Serialize};
 use std::{
     env,
-    time::{Duration, SystemTime, UNIX_EPOCH},
     fs::File,
     io::BufReader,
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
-use jsonwebtoken as jwt;
 
 #[derive(Deserialize)]
 pub struct GoogleCredentials {
@@ -22,11 +22,11 @@ pub struct GoogleAccessTokenResponse {
 
 #[derive(Deserialize)]
 pub struct GoogleSecretResponse {
-    pub payload: GoogleSecretResponsePayload
+    pub payload: GoogleSecretResponsePayload,
 }
 #[derive(Deserialize)]
 pub struct GoogleSecretResponsePayload {
-    pub data: String 
+    pub data: String,
 }
 
 #[derive(Serialize, Debug)]
@@ -38,23 +38,30 @@ pub struct GoogleApiClaims<'a> {
     iat: u64,
 }
 
-impl <'a> GoogleApiClaims <'a> {
-    pub fn new(credentials:&'a GoogleCredentials) -> Self {
+impl<'a> GoogleApiClaims<'a> {
+    pub fn new(credentials: &'a GoogleCredentials) -> Self {
         Self {
             iss: &credentials.client_email,
             scope: "https://www.googleapis.com/auth/cloud-platform",
             aud: "https://oauth2.googleapis.com/token",
-            exp: (SystemTime::now() + Duration::from_secs(3600)).duration_since(UNIX_EPOCH).expect("get duration").as_secs(),
-            iat: SystemTime::now().duration_since(UNIX_EPOCH).expect("get duration").as_secs()
+            exp: (SystemTime::now() + Duration::from_secs(3600))
+                .duration_since(UNIX_EPOCH)
+                .expect("get duration")
+                .as_secs(),
+            iat: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("get duration")
+                .as_secs(),
         }
     }
 }
 
-pub async fn get_google_credentials(env_var_name:&str) -> Result<GoogleCredentials, String> {
+pub async fn get_google_credentials(env_var_name: &str) -> Result<GoogleCredentials, String> {
     env::var(env_var_name)
         .map_err(|_| format!("no {} set", env_var_name))
         .and_then(|credentials_path| {
-            File::open(credentials_path.clone()).map_err(|_| format!("couldn't open {}", credentials_path))
+            File::open(credentials_path.clone())
+                .map_err(|_| format!("couldn't open {}", credentials_path))
         })
         .and_then(|credentials_file| {
             let reader = BufReader::new(credentials_file);
@@ -62,11 +69,15 @@ pub async fn get_google_credentials(env_var_name:&str) -> Result<GoogleCredentia
         })
 }
 
-pub async fn get_google_token_from_credentials(credentials:&GoogleCredentials) -> Result<String, String> {
-
+pub async fn get_google_token_from_credentials(
+    credentials: &GoogleCredentials,
+) -> Result<String, String> {
     let claims = GoogleApiClaims::new(&credentials);
-    let token_assertion = jwt::encode(&jwt::Header::new(jwt::Algorithm::RS256), &claims, &jwt::EncodingKey::from_rsa_pem(credentials.private_key.as_bytes())
-        .map_err(|_| "couldn't get encoding key".to_string())?
+    let token_assertion = jwt::encode(
+        &jwt::Header::new(jwt::Algorithm::RS256),
+        &claims,
+        &jwt::EncodingKey::from_rsa_pem(credentials.private_key.as_bytes())
+            .map_err(|_| "couldn't get encoding key".to_string())?,
     )
     .map_err(|_| "couldn't encode jwt for google api request".to_string())?;
 
@@ -74,83 +85,95 @@ pub async fn get_google_token_from_credentials(credentials:&GoogleCredentials) -
         .text("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer")
         .text("assertion", token_assertion);
 
-    let token_response:GoogleAccessTokenResponse = reqwest::Client::new()
+    let token_response: GoogleAccessTokenResponse = reqwest::Client::new()
         .post("https://oauth2.googleapis.com/token")
         .multipart(form)
         .send()
         .and_then(|res| res.json())
         .await
         .map_err(|err| format!("couldn't get google access token: {:?}", err))?;
-    
+
     Ok(token_response.access_token)
 }
 
 pub async fn get_google_token_from_metaserver() -> Result<String, String> {
-    
     let url = "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
 
-    let token_response:GoogleAccessTokenResponse = reqwest::Client::new().get(url)
-        .header("Metadata-Flavor","Google")
+    let token_response: GoogleAccessTokenResponse = reqwest::Client::new()
+        .get(url)
+        .header("Metadata-Flavor", "Google")
         .send()
         .and_then(|res| res.json())
         /*
         .and_then(|res| async move {
             //res.json()
-            
             let text = res.text().await.expect("couldn't get response text to log");
-            eprintln!("raw: {}", text); 
+            eprintln!("raw: {}", text);
             let json = serde_json::from_str(&text).unwrap();
             Ok(json)
-
         })
         */
         .await
-        .map_err(|err| format!("couldn't get google access token from metaserver: {:?}", err))?;
-    
+        .map_err(|err| {
+            format!(
+                "couldn't get google access token from metaserver: {:?}",
+                err
+            )
+        })?;
+
     Ok(token_response.access_token)
 }
 
-pub async fn get_access_token_and_project_id(credentials_env_var_name:&str) -> Result<(String, String), String> {
+pub async fn get_access_token_and_project_id(
+    credentials_env_var_name: &str,
+) -> Result<(String, String), String> {
     let credentials = get_google_credentials(credentials_env_var_name).await;
     match credentials {
         Ok(credentials) => {
             let token = get_google_token_from_credentials(&credentials).await?;
             Ok((token, credentials.project_id))
-        },
+        }
         Err(_) => {
-            let project_id = env::var("PROJECT_ID").map_err(|_| format!("You must set PROJECT_ID as an env var since there's no {}", credentials_env_var_name))?;
+            let project_id = env::var("PROJECT_ID").map_err(|_| {
+                format!(
+                    "You must set PROJECT_ID as an env var since there's no {}",
+                    credentials_env_var_name
+                )
+            })?;
             let token = get_google_token_from_metaserver().await?;
             Ok((token, project_id))
         }
     }
 }
 
-pub async fn get_secret(token:&str, project_id:&str, secret_name:&str) -> String {
-    let api_name = format!("projects/{}/secrets/{}/versions/latest:access", project_id, secret_name);
+pub async fn get_secret(token: &str, project_id: &str, secret_name: &str) -> String {
+    let api_name = format!(
+        "projects/{}/secrets/{}/versions/latest:access",
+        project_id, secret_name
+    );
 
     let path = format!("https://secretmanager.googleapis.com/v1beta1/{}", api_name);
 
-    let request = reqwest::Client::new().get(&path)
-        .header("Authorization",&format!("Bearer {}", token));
+    let request = reqwest::Client::new()
+        .get(&path)
+        .header("Authorization", &format!("Bearer {}", token));
 
-    let response:GoogleSecretResponse = request
+    let response: GoogleSecretResponse = request
         .send()
         .and_then(|res| res.json())
         /*
         .and_then(|res| async move {
             //res.json()
-            
             let text = res.text().await.expect("couldn't get response text to log");
-            eprintln!("raw: {}", text); 
+            eprintln!("raw: {}", text);
             let json = serde_json::from_str(&text).unwrap();
             Ok(json)
-
         })
         */
         .await
         .expect(&format!("couldn't get secret: {}", secret_name));
 
-    let bytes:Vec<u8> = base64::decode(response.payload.data).unwrap();
+    let bytes: Vec<u8> = base64::decode(response.payload.data).unwrap();
     std::str::from_utf8(&bytes).unwrap().to_string()
 }
 
@@ -160,11 +183,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_secrets() {
-
         dotenv::dotenv().ok();
 
-        let credentials = get_google_credentials("GOOGLE_APPLICATION_CREDENTIALS_DEV_SANDBOX").await.unwrap();
-        let token = get_google_token_from_credentials(&credentials).await.unwrap();
+        let credentials = get_google_credentials("GOOGLE_APPLICATION_CREDENTIALS_DEV_SANDBOX")
+            .await
+            .unwrap();
+        let token = get_google_token_from_credentials(&credentials)
+            .await
+            .unwrap();
         let secret = get_secret(&token, &credentials.project_id, "SANITY_TEST").await;
 
         assert_eq!(secret, "hello_world");

--- a/backend/_core/rust/src/settings.rs
+++ b/backend/_core/rust/src/settings.rs
@@ -1,16 +1,14 @@
+use super::google::{get_access_token_and_project_id, get_secret};
+use cfg_if::cfg_if;
+use config::RemoteTarget;
 use jsonwebtoken::EncodingKey;
+use once_cell::sync::OnceCell;
 use std::{
     fmt,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
-use super::google::{get_secret, get_access_token_and_project_id};
-use config::RemoteTarget;
-use once_cell::sync::OnceCell;
-use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
-use cfg_if::cfg_if;
 
-
-pub static SETTINGS:OnceCell<Settings> = OnceCell::new();
+pub static SETTINGS: OnceCell<Settings> = OnceCell::new();
 
 pub struct Settings {
     pub remote_target: RemoteTarget,
@@ -22,59 +20,84 @@ pub struct Settings {
     pub jwt_encoding_key: EncodingKey,
     //TODO see: https://github.com/Keats/jsonwebtoken/issues/120#issuecomment-634096881
     //Keeping a string is a stop-gap measure for now, not ideal
-    pub jwt_decoding_key:String,
-    pub inter_server_secret:String,
-    pub db_credentials:DbCredentials,
+    pub jwt_decoding_key: String,
+    pub inter_server_secret: String,
+    pub db_credentials: DbCredentials,
 }
 
 cfg_if! {
     if #[cfg(all(feature = "local", feature = "sqlproxy"))] {
-        pub async fn init() { 
+        pub async fn init() {
             _init(RemoteTarget::Local, DbTarget::Proxy).await;
         }
     } else if #[cfg(feature = "local")] {
-        pub async fn init() { 
+        pub async fn init() {
             _init(RemoteTarget::Local, DbTarget::Local).await;
         }
     } else if #[cfg(feature = "sandbox")] {
-		pub async fn init() { 
+        pub async fn init() {
             _init(RemoteTarget::Sandbox, DbTarget::Remote(RemoteTarget::Sandbox)).await;
         }
-        
+
     } else if #[cfg(feature = "release")] {
-        pub async fn init() { 
+        pub async fn init() {
             _init(RemoteTarget::Release, DbTarget::Remote(RemoteTarget::Release)).await;
         }
     } else {
-        pub async fn init() { 
+        pub async fn init() {
         }
-    } 
+    }
 }
 
-
-async fn _init(remote_target:RemoteTarget, db_target:DbTarget) {
-    let (token, project_id) = get_access_token_and_project_id(remote_target.google_credentials_env_name()).await.expect("couldn't get access token and project id!");
+async fn _init(remote_target: RemoteTarget, db_target: DbTarget) {
+    let (token, project_id) =
+        get_access_token_and_project_id(remote_target.google_credentials_env_name())
+            .await
+            .expect("couldn't get access token and project id!");
 
     let jwt_secret = get_secret(token.as_ref(), &project_id, "JWT_SECRET").await;
     let db_pass = get_secret(token.as_ref(), &project_id, "DB_PASS").await;
     let inter_server_secret = get_secret(token.as_ref(), &project_id, "INTER_SERVER").await;
-
 
     let jwt_encoding_key = EncodingKey::from_secret(jwt_secret.as_ref());
 
     //TODO see: https://github.com/Keats/jsonwebtoken/issues/120#issuecomment-634096881
     //Keeping a string is a stop-gap measure for now, not ideal
 
-    SETTINGS.set(match remote_target {
-        RemoteTarget::Local => Settings::new_local(db_target, jwt_encoding_key, jwt_secret, inter_server_secret, db_pass),
-        RemoteTarget::Sandbox => Settings::new_sandbox(db_target, jwt_encoding_key, jwt_secret, inter_server_secret, db_pass),
-        RemoteTarget::Release => Settings::new_release(db_target, jwt_encoding_key, jwt_secret, inter_server_secret, db_pass),
-    }).expect("couldn't set settings!");
+    SETTINGS
+        .set(match remote_target {
+            RemoteTarget::Local => Settings::new_local(
+                db_target,
+                jwt_encoding_key,
+                jwt_secret,
+                inter_server_secret,
+                db_pass,
+            ),
+            RemoteTarget::Sandbox => Settings::new_sandbox(
+                db_target,
+                jwt_encoding_key,
+                jwt_secret,
+                inter_server_secret,
+                db_pass,
+            ),
+            RemoteTarget::Release => Settings::new_release(
+                db_target,
+                jwt_encoding_key,
+                jwt_secret,
+                inter_server_secret,
+                db_pass,
+            ),
+        })
+        .expect("couldn't set settings!");
 }
 
 impl fmt::Debug for Settings {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "remote_target is [{:?}]. api_port is [{}] pages_port is [{}]", self.remote_target, self.api_port, self.pages_port)
+        write!(
+            f,
+            "remote_target is [{:?}]. api_port is [{}] pages_port is [{}]",
+            self.remote_target, self.api_port, self.pages_port
+        )
     }
 }
 fn get_epoch() -> Duration {
@@ -83,16 +106,26 @@ fn get_epoch() -> Duration {
         .expect("Time went backwards")
 }
 
-
-
 impl Settings {
-    pub fn new_local(db_target:DbTarget, jwt_encoding_key:EncodingKey, jwt_decoding_key: String, inter_server_secret:String, db_pass:String) -> Self {
+    pub fn new_local(
+        db_target: DbTarget,
+        jwt_encoding_key: EncodingKey,
+        jwt_decoding_key: String,
+        inter_server_secret: String,
+        db_pass: String,
+    ) -> Self {
         Self {
             remote_target: RemoteTarget::Local,
-            db_target, 
+            db_target,
             local_insecure: true,
-            api_port: std::env::var("LOCAL_API_PORT").expect("set LOCAL_API_PORT").parse().unwrap(),
-            pages_port: std::env::var("LOCAL_PAGES_PORT").expect("set LOCAL_PAGES_PORT").parse().unwrap(),
+            api_port: std::env::var("LOCAL_API_PORT")
+                .expect("set LOCAL_API_PORT")
+                .parse()
+                .unwrap(),
+            pages_port: std::env::var("LOCAL_PAGES_PORT")
+                .expect("set LOCAL_PAGES_PORT")
+                .parse()
+                .unwrap(),
             epoch: get_epoch(),
             jwt_encoding_key,
             jwt_decoding_key,
@@ -100,10 +133,16 @@ impl Settings {
             db_credentials: DbCredentials::new(&db_pass, db_target),
         }
     }
-    pub fn new_sandbox(db_target:DbTarget, jwt_encoding_key:EncodingKey, jwt_decoding_key: String, inter_server_secret:String, db_pass:String) -> Self {
+    pub fn new_sandbox(
+        db_target: DbTarget,
+        jwt_encoding_key: EncodingKey,
+        jwt_decoding_key: String,
+        inter_server_secret: String,
+        db_pass: String,
+    ) -> Self {
         Self {
             remote_target: RemoteTarget::Sandbox,
-            db_target, 
+            db_target,
             api_port: 8080,
             pages_port: 8080,
             local_insecure: false,
@@ -114,10 +153,16 @@ impl Settings {
             db_credentials: DbCredentials::new(&db_pass, db_target),
         }
     }
-    pub fn new_release(db_target:DbTarget, jwt_encoding_key:EncodingKey, jwt_decoding_key: String, inter_server_secret:String, db_pass:String) -> Self {
+    pub fn new_release(
+        db_target: DbTarget,
+        jwt_encoding_key: EncodingKey,
+        jwt_decoding_key: String,
+        inter_server_secret: String,
+        db_pass: String,
+    ) -> Self {
         Self {
             remote_target: RemoteTarget::Release,
-            db_target, 
+            db_target,
             api_port: 8080,
             pages_port: 8080,
             local_insecure: false,
@@ -139,63 +184,73 @@ pub enum DbTarget {
 
 #[derive(Debug)]
 pub struct DbCredentials {
-    pub dbname:String,
-    pub user:String,
-    pub pass:String,
+    pub dbname: String,
+    pub user: String,
+    pub pass: String,
     pub endpoint: DbEndpoint,
 }
 #[derive(Debug)]
 pub enum DbEndpoint {
     Socket(String),
-    Tcp(String, u16)
+    Tcp(String, u16),
 }
 
 impl DbCredentials {
-    pub fn new(secret_db_pass:&str, db_target:DbTarget) -> Self {
+    pub fn new(secret_db_pass: &str, db_target: DbTarget) -> Self {
         match db_target {
             DbTarget::Local => {
                 //these are env vars since it depends on developer's local machine
-                let user = std::env::var("LOCAL_DB_USER").expect("When not using Cloud Sql Proxy, set LOCAL_DB_USER in .env");
-                let pass = std::env::var("LOCAL_DB_PASS").expect("When not using Cloud Sql Proxy, set LOCAL_DB_PASS in .env");
-                let port = std::env::var("LOCAL_DB_PORT").expect("When not using Cloud Sql Proxy, set LOCAL_DB_PORT in .env");
-                let dbname = std::env::var("LOCAL_DB_NAME").expect("When not using Cloud Sql Proxy, set LOCAL_DB_NAME in .env");
+                let user = std::env::var("LOCAL_DB_USER")
+                    .expect("When not using Cloud Sql Proxy, set LOCAL_DB_USER in .env");
+                let pass = std::env::var("LOCAL_DB_PASS")
+                    .expect("When not using Cloud Sql Proxy, set LOCAL_DB_PASS in .env");
+                let port = std::env::var("LOCAL_DB_PORT")
+                    .expect("When not using Cloud Sql Proxy, set LOCAL_DB_PORT in .env");
+                let dbname = std::env::var("LOCAL_DB_NAME")
+                    .expect("When not using Cloud Sql Proxy, set LOCAL_DB_NAME in .env");
                 let host = "localhost".to_string();
 
-                let port:u16 = port.parse().expect("Port must be a u32");
+                let port: u16 = port.parse().expect("Port must be a u32");
 
-                Self { user, pass, dbname, endpoint: DbEndpoint::Tcp(host, port) }
-            },
-            DbTarget::Proxy => {
-                Self { 
-                    user: config::REMOTE_DB_USER.to_string(), 
-                    pass: secret_db_pass.to_string(),
-                    dbname: config::REMOTE_DB_NAME.to_string(), 
-                    endpoint: DbEndpoint::Tcp("localhost".to_string(), config::SQL_PROXY_PORT)
+                Self {
+                    user,
+                    pass,
+                    dbname,
+                    endpoint: DbEndpoint::Tcp(host, port),
                 }
+            }
+            DbTarget::Proxy => Self {
+                user: config::REMOTE_DB_USER.to_string(),
+                pass: secret_db_pass.to_string(),
+                dbname: config::REMOTE_DB_NAME.to_string(),
+                endpoint: DbEndpoint::Tcp("localhost".to_string(), config::SQL_PROXY_PORT),
             },
             DbTarget::Remote(remote_target) => {
-                let instance_connection = 
-                    std::env::var("INSTANCE_CONNECTION_NAME")
-                        .unwrap_or(match remote_target {
-                            RemoteTarget::Sandbox => config::DB_INSTANCE_SANDBOX.to_string(),
-                            RemoteTarget::Release => config::DB_INSTANCE_RELEASE.to_string(), 
-                            _ => panic!("non-dev mode only makes sense for sandbox or release")
-                        });
+                let instance_connection =
+                    std::env::var("INSTANCE_CONNECTION_NAME").unwrap_or(match remote_target {
+                        RemoteTarget::Sandbox => config::DB_INSTANCE_SANDBOX.to_string(),
+                        RemoteTarget::Release => config::DB_INSTANCE_RELEASE.to_string(),
+                        _ => panic!("non-dev mode only makes sense for sandbox or release"),
+                    });
 
-                let socket_path = std::env::var("DB_SOCKET_PATH").unwrap_or("/cloudsql".to_string());
+                let socket_path =
+                    std::env::var("DB_SOCKET_PATH").unwrap_or("/cloudsql".to_string());
 
-                Self { 
-                    user: config::REMOTE_DB_USER.to_string(), 
+                Self {
+                    user: config::REMOTE_DB_USER.to_string(),
                     pass: secret_db_pass.to_string(),
-                    dbname: config::REMOTE_DB_NAME.to_string(), 
-                    endpoint: DbEndpoint::Socket(format!("{}/{}", socket_path, instance_connection))
+                    dbname: config::REMOTE_DB_NAME.to_string(),
+                    endpoint: DbEndpoint::Socket(format!(
+                        "{}/{}",
+                        socket_path, instance_connection
+                    )),
                 }
                 /*
-                let instance_connection = 
+                let instance_connection =
                     std::env::var("INSTANCE_CONNECTION_NAME")
                         .unwrap_or(match remote_target {
                             RemoteTarget::Sandbox => DB_INSTANCE_SANDBOX.to_string(),
-                            RemoteTarget::Release => DB_INSTANCE_RELEASE.to_string(), 
+                            RemoteTarget::Release => DB_INSTANCE_RELEASE.to_string(),
                             _ => panic!("non-dev mode only makes sense for sandbox or release")
                         });
 
@@ -214,8 +269,14 @@ impl DbCredentials {
 
     pub fn to_string(&self) -> String {
         match &self.endpoint {
-            DbEndpoint::Tcp(host, port) => format!("postgres:///{}?user={}&password={}&host={}&port={}", self.dbname, self.user, self.pass, host, port),
-            DbEndpoint::Socket(path) => format!("postgres:///{}?user={}&password={}&host={}", self.dbname, self.user, self.pass, path),
+            DbEndpoint::Tcp(host, port) => format!(
+                "postgres:///{}?user={}&password={}&host={}&port={}",
+                self.dbname, self.user, self.pass, host, port
+            ),
+            DbEndpoint::Socket(path) => format!(
+                "postgres:///{}?user={}&password={}&host={}",
+                self.dbname, self.user, self.pass, path
+            ),
         }
     }
 }

--- a/backend/api/crates/actions/src/auth.rs
+++ b/backend/api/crates/actions/src/auth.rs
@@ -1,38 +1,34 @@
-use futures_util::future::TryFutureExt;
-use shared::{
-    auth::{SigninSuccess, RegisterSuccess, AuthClaims, JWT_COOKIE_NAME, CSRF_HEADER_NAME},
-    user::UserRole,
-    api::result::ResultResponse
-};
-use serde::{Serialize, Deserialize};
-use jsonwebtoken as jwt;
-use rand::{thread_rng, Rng};
-use rand::distributions::Alphanumeric;
 use crate::user::get_by_id;
 use core::settings::SETTINGS;
-use config::{MAX_SIGNIN_COOKIE, COOKIE_DOMAIN};
+use futures_util::future::TryFutureExt;
+use jsonwebtoken as jwt;
+use serde::{Deserialize, Serialize};
+use shared::auth::AuthClaims;
 use sqlx::postgres::PgPool;
 
 pub enum Error {
     Jwt(jwt::errors::Error),
     Csrf,
     NoUser,
-    Firebase
+    Firebase,
 }
 
-pub fn get_claims(token_string:&str) -> Result<AuthClaims, Error> {
-
+pub fn get_claims(token_string: &str) -> Result<AuthClaims, Error> {
     //see: https://github.com/Keats/jsonwebtoken/issues/120#issuecomment-634096881
-    let key = jsonwebtoken::DecodingKey::from_secret(SETTINGS.get().unwrap().jwt_decoding_key.as_ref());
+    let key =
+        jsonwebtoken::DecodingKey::from_secret(SETTINGS.get().unwrap().jwt_decoding_key.as_ref());
 
-    let validation = jwt::Validation {validate_exp: false, ..Default::default()};
+    let validation = jwt::Validation {
+        validate_exp: false,
+        ..Default::default()
+    };
 
     jsonwebtoken::decode::<AuthClaims>(&token_string, &key, &validation)
         .map(|decoded| decoded.claims)
         .map_err(|err| Error::Jwt(err))
 }
 
-pub async fn check_full(db:&PgPool, token_string:&str, csrf:&str) -> Result<AuthClaims, Error> {
+pub async fn check_full(db: &PgPool, token_string: &str, csrf: &str) -> Result<AuthClaims, Error> {
     let claims = check_no_db(token_string, csrf)?;
 
     if get_by_id(&db, &claims.id).await.is_none() {
@@ -42,20 +38,17 @@ pub async fn check_full(db:&PgPool, token_string:&str, csrf:&str) -> Result<Auth
     }
 }
 
-pub fn check_no_db(token_string:&str, csrf:&str) -> Result<AuthClaims, Error> {
-    get_claims(token_string)
-        .and_then(|claims| {
-            if claims.csrf.as_deref() == Some(csrf) {
-                Ok(claims)
-            } else {
-                Err(Error::Csrf)
-            }
-        })
+pub fn check_no_db(token_string: &str, csrf: &str) -> Result<AuthClaims, Error> {
+    get_claims(token_string).and_then(|claims| {
+        if claims.csrf.as_deref() == Some(csrf) {
+            Ok(claims)
+        } else {
+            Err(Error::Csrf)
+        }
+    })
 }
-pub async fn check_no_csrf(db:&PgPool, token_string:&str) -> Result<AuthClaims, Error> {
-
+pub async fn check_no_csrf(db: &PgPool, token_string: &str) -> Result<AuthClaims, Error> {
     let claims = get_claims(token_string)?;
-            
 
     if get_by_id(&db, &claims.id).await.is_none() {
         Err(Error::NoUser)
@@ -64,10 +57,10 @@ pub async fn check_no_csrf(db:&PgPool, token_string:&str) -> Result<AuthClaims, 
     }
 }
 
-pub async fn get_firebase_id(token:&str) -> Result<String, Error> {
+pub async fn get_firebase_id(token: &str) -> Result<String, Error> {
     #[derive(Deserialize)]
     struct JsApiResponse {
-        valid: bool
+        valid: bool,
     }
 
     //use the js server to handle this, since it has the official firebase admin sdk
@@ -75,28 +68,32 @@ pub async fn get_firebase_id(token:&str) -> Result<String, Error> {
     //1. https://github.com/Keats/jsonwebtoken/issues/127
     //2. all the specific claim checks (e.g. timestamp comparisons)
 
-    let response:JsApiResponse = 
-        reqwest::Client::new()
-            .get(&format!("{}/validate-firebase-token/{}", SETTINGS.get().unwrap().remote_target.api_js_url(), token))
-            .header("INTER_SERVER_SECRET", &SETTINGS.get().unwrap().inter_server_secret)
-            .send()
-            .and_then(|res| res.json::<JsApiResponse>())
-            .await
-            .map_err(|err| {
-                log::warn!("js/firebase error, shouldn't happen: {:?}", err);
-                Error::Firebase
-            })?;
+    let response: JsApiResponse = reqwest::Client::new()
+        .get(&format!(
+            "{}/validate-firebase-token/{}",
+            SETTINGS.get().unwrap().remote_target.api_js_url(),
+            token
+        ))
+        .header(
+            "INTER_SERVER_SECRET",
+            &SETTINGS.get().unwrap().inter_server_secret,
+        )
+        .send()
+        .and_then(|res| res.json::<JsApiResponse>())
+        .await
+        .map_err(|err| {
+            log::warn!("js/firebase error, shouldn't happen: {:?}", err);
+            Error::Firebase
+        })?;
 
     if response.valid {
-
         #[derive(Debug, Serialize, Deserialize)]
         struct FirebaseClaims {
             sub: String,
         }
-        let claims:FirebaseClaims = 
-            jwt::dangerous_unsafe_decode::<FirebaseClaims>(&token)
-                .map_err(|err| Error::Firebase)?
-                .claims;
+        let claims: FirebaseClaims = jwt::dangerous_insecure_decode::<FirebaseClaims>(&token)
+            .map_err(|_| Error::Firebase)?
+            .claims;
 
         let user_id = claims.sub;
 

--- a/backend/api/crates/actions/src/lib.rs
+++ b/backend/api/crates/actions/src/lib.rs
@@ -1,5 +1,2 @@
-//see: https://github.com/rust-lang/cargo/issues/8010
-#![cfg_attr(feature = "quiet", allow(warnings))]
-
-pub mod user;
 pub mod auth;
+pub mod user;

--- a/backend/api/crates/actions/src/user.rs
+++ b/backend/api/crates/actions/src/user.rs
@@ -57,19 +57,25 @@ pub async fn register(
     user_id: &str,
     req: &RegisterRequest,
 ) -> Result<(), RegisterError> {
-    let _ = if get_by_id(&db, &user_id).await.is_some() {
-        Err(RegisterError::TakenId)
-    } else if req.display_name.is_empty() {
-        Err(RegisterError::EmptyDisplayname)
-    } else if req.first_name.is_empty() {
-        Err(RegisterError::EmptyFirstname)
-    } else if req.last_name.is_empty() {
-        Err(RegisterError::EmptyLastname)
-    } else if get_by_email(&db, &req.email).await.is_some() {
-        Err(RegisterError::TakenEmail)
-    } else {
-        Ok(())
-    }?;
+    if get_by_id(&db, &user_id).await.is_some() {
+        return Err(RegisterError::TakenId);
+    }
+
+    if req.display_name.is_empty() {
+        return Err(RegisterError::EmptyDisplayname);
+    }
+
+    if req.first_name.is_empty() {
+        return Err(RegisterError::EmptyFirstname);
+    }
+
+    if req.last_name.is_empty() {
+        return Err(RegisterError::EmptyLastname);
+    }
+
+    if get_by_email(&db, &req.email).await.is_some() {
+        return Err(RegisterError::TakenEmail);
+    }
 
     sqlx::query(
         r#"

--- a/backend/api/crates/server/src/auth.rs
+++ b/backend/api/crates/server/src/auth.rs
@@ -1,118 +1,138 @@
-use futures_util::future::TryFutureExt;
-use warp::{
-    Filter, 
-    Rejection
-};
-use shared::{
-    auth::{SigninSuccess, RegisterSuccess, AuthClaims, JWT_COOKIE_NAME, CSRF_HEADER_NAME},
-    user::UserRole,
-    api::result::ResultResponse
-};
-use serde::{Serialize, Deserialize};
-use jsonwebtoken as jwt;
-use rand::{thread_rng, Rng};
-use rand::distributions::Alphanumeric;
-use actions::user::get_by_id;
-use crate::reject::{CustomWarpRejection, NoAuth, PgPoolError, InternalError};
+use crate::reject::{CustomWarpRejection, InternalError, NoAuth};
+use actions::auth::{check_full, check_no_csrf, check_no_db, get_claims, get_firebase_id};
+use config::{COOKIE_DOMAIN, MAX_SIGNIN_COOKIE};
 use core::settings::SETTINGS;
-use config::{MAX_SIGNIN_COOKIE, COOKIE_DOMAIN};
+use jsonwebtoken as jwt;
+use rand::distributions::Alphanumeric;
+use rand::{thread_rng, Rng};
+use shared::{
+    api::result::ResultResponse,
+    auth::{AuthClaims, RegisterSuccess, SigninSuccess, CSRF_HEADER_NAME, JWT_COOKIE_NAME},
+    user::UserRole,
+};
 use sqlx::postgres::PgPool;
-use crate::{async_clone_fn, async_clone_cb};
-use actions::auth::{get_claims, check_full, check_no_db, check_no_csrf, get_firebase_id};
+use warp::{Filter, Rejection};
 
 //This can be used to early exit if there's no bearer token
 //is just used internally, the top-level uses specific auth guards (firebase, user, etc.)
 fn has_bearer_token() -> impl Filter<Extract = (String,), Error = warp::Rejection> + Clone {
     warp::header::<String>("Authorization")
-        .or_else(|_| async {Err(NoAuth::rejection())})
-        .map(|bearer_token: String| { bearer_token.replace("Bearer ", "") })
+        .or_else(|_| async { Err(NoAuth::rejection()) })
+        .map(|bearer_token: String| bearer_token.replace("Bearer ", ""))
 }
 
 //Had some type sig trouble trying to keep this DRY... if you can improve it, great!
 
-pub fn has_auth_full(db:PgPool) -> impl Filter<Extract = (AuthClaims,), Error = Rejection> + Clone {
+pub fn has_auth_full(
+    db: PgPool,
+) -> impl Filter<Extract = (AuthClaims,), Error = Rejection> + Clone {
     warp::filters::cookie::cookie(JWT_COOKIE_NAME)
         .and(
             warp::header::<String>(CSRF_HEADER_NAME)
-            .or_else(|_| async {Err(NoAuth::rejection())})
+                .or_else(|_| async { Err(NoAuth::rejection()) }),
         )
-        .and_then(move |cookie:String, csrf:String| {
-                let db = db.clone();
-                async move {
-                    check_full(&db, &cookie, &csrf).await.map_err(|_| NoAuth::rejection())
-                }
+        .and_then(move |cookie: String, csrf: String| {
+            let db = db.clone();
+            async move {
+                check_full(&db, &cookie, &csrf)
+                    .await
+                    .map_err(|_| NoAuth::rejection())
             }
-        )
+        })
 }
 
 pub fn has_auth_no_db() -> impl Filter<Extract = (AuthClaims,), Error = Rejection> + Clone {
     warp::filters::cookie::cookie(JWT_COOKIE_NAME)
         .and(
             warp::header::<String>(CSRF_HEADER_NAME)
-            .or_else(|_| {
-                async {Err(NoAuth::rejection())}
-            })
+                .or_else(|_| async { Err(NoAuth::rejection()) }),
         )
-        .and_then(|cookie:String, csrf:String| async move {
+        .and_then(|cookie: String, csrf: String| async move {
             check_no_db(&cookie, &csrf).map_err(|_| NoAuth::rejection())
         })
 }
 
-
-pub fn has_auth_cookie_and_db_no_csrf(db:PgPool) -> impl Filter<Extract = (AuthClaims,), Error = Rejection> + Clone {
-    warp::filters::cookie::cookie(JWT_COOKIE_NAME)
-        .and_then(move |cookie:String| {
-                let db = db.clone();
-                async move {
-                    check_no_csrf(&db, &cookie).await.map_err(|_| NoAuth::rejection())
-                }
-            }
-        )
+pub fn has_auth_cookie_and_db_no_csrf(
+    db: PgPool,
+) -> impl Filter<Extract = (AuthClaims,), Error = Rejection> + Clone {
+    warp::filters::cookie::cookie(JWT_COOKIE_NAME).and_then(move |cookie: String| {
+        let db = db.clone();
+        async move {
+            check_no_csrf(&db, &cookie)
+                .await
+                .map_err(|_| NoAuth::rejection())
+        }
+    })
 }
 
-pub fn has_auth_cookie_no_db_nor_csrf() -> impl Filter<Extract = (AuthClaims,), Error = Rejection> + Clone {
-    warp::filters::cookie::cookie(JWT_COOKIE_NAME)
-        .and_then(|cookie:String| async move {
-            get_claims(&cookie).map_err(|_| NoAuth::rejection())
-        })
+pub fn has_auth_cookie_no_db_nor_csrf(
+) -> impl Filter<Extract = (AuthClaims,), Error = Rejection> + Clone {
+    warp::filters::cookie::cookie(JWT_COOKIE_NAME).and_then(|cookie: String| async move {
+        get_claims(&cookie).map_err(|_| NoAuth::rejection())
+    })
 }
 
 //returns the user id if firebase is authenticated
 pub fn has_firebase_auth() -> impl Filter<Extract = (String,), Error = Rejection> + Clone {
-    has_bearer_token()
-        .and_then(|token: String| async move {
-            let token = token.replace("Bearer ", "");
-            get_firebase_id(&token).await.map_err(|_| NoAuth::rejection())
-        })
+    has_bearer_token().and_then(|token: String| async move {
+        let token = token.replace("Bearer ", "");
+        get_firebase_id(&token)
+            .await
+            .map_err(|_| NoAuth::rejection())
+    })
 }
 
-pub fn reply_signin_auth(user_id:String, roles: Vec<UserRole>, is_register:bool) -> Result<warp::reply::WithHeader<warp::reply::Json>, warp::Rejection> {
-    let csrf:String = thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(16)
-        .collect();
+pub fn reply_signin_auth(
+    user_id: String,
+    roles: Vec<UserRole>,
+    is_register: bool,
+) -> Result<warp::reply::WithHeader<warp::reply::Json>, warp::Rejection> {
+    let csrf: String = thread_rng().sample_iter(&Alphanumeric).take(16).collect();
 
     let claims = AuthClaims {
         id: user_id,
         csrf: Some(csrf.clone()),
-        roles
+        roles,
     };
 
-    let jwt = jwt::encode(&jwt::Header::default(), &claims, &SETTINGS.get().unwrap().jwt_encoding_key).map_err(|_| InternalError::rejection())?;
+    let jwt = jwt::encode(
+        &jwt::Header::default(),
+        &claims,
+        &SETTINGS.get().unwrap().jwt_encoding_key,
+    )
+    .map_err(|_| InternalError::rejection())?;
 
     let reply = {
         if is_register {
-            warp::reply::json(&ResultResponse::Ok::<RegisterSuccess, ()>(RegisterSuccess::Signin(csrf)))
+            warp::reply::json(&ResultResponse::Ok::<RegisterSuccess, ()>(
+                RegisterSuccess::Signin(csrf),
+            ))
         } else {
-            warp::reply::json(&ResultResponse::Ok::<SigninSuccess, ()>(SigninSuccess{csrf}))
+            warp::reply::json(&ResultResponse::Ok::<SigninSuccess, ()>(SigninSuccess {
+                csrf,
+            }))
         }
     };
 
     let reply = {
-        if(SETTINGS.get().unwrap().local_insecure) {
-            warp::reply::with_header(reply, "Set-Cookie", &format!("{}={}; HttpOnly; SameSite=Lax; Max-Age={}", JWT_COOKIE_NAME, jwt, MAX_SIGNIN_COOKIE))
+        if SETTINGS.get().unwrap().local_insecure {
+            warp::reply::with_header(
+                reply,
+                "Set-Cookie",
+                &format!(
+                    "{}={}; HttpOnly; SameSite=Lax; Max-Age={}",
+                    JWT_COOKIE_NAME, jwt, MAX_SIGNIN_COOKIE
+                ),
+            )
         } else {
-            warp::reply::with_header(reply, "Set-Cookie", &format!("{}={}; Secure; HttpOnly; SameSite=Lax; Max-Age={}; domain={}", JWT_COOKIE_NAME, jwt, MAX_SIGNIN_COOKIE, COOKIE_DOMAIN))
+            warp::reply::with_header(
+                reply,
+                "Set-Cookie",
+                &format!(
+                    "{}={}; Secure; HttpOnly; SameSite=Lax; Max-Age={}; domain={}",
+                    JWT_COOKIE_NAME, jwt, MAX_SIGNIN_COOKIE, COOKIE_DOMAIN
+                ),
+            )
         }
     };
 

--- a/backend/api/crates/server/src/auth.rs
+++ b/backend/api/crates/server/src/auth.rs
@@ -23,7 +23,7 @@ fn has_bearer_token() -> impl Filter<Extract = (String,), Error = warp::Rejectio
 
 //Had some type sig trouble trying to keep this DRY... if you can improve it, great!
 
-pub fn has_auth_full(
+pub fn _has_auth_full(
     db: PgPool,
 ) -> impl Filter<Extract = (AuthClaims,), Error = Rejection> + Clone {
     warp::filters::cookie::cookie(JWT_COOKIE_NAME)
@@ -65,7 +65,7 @@ pub fn has_auth_cookie_and_db_no_csrf(
     })
 }
 
-pub fn has_auth_cookie_no_db_nor_csrf(
+pub fn _has_auth_cookie_no_db_nor_csrf(
 ) -> impl Filter<Extract = (AuthClaims,), Error = Rejection> + Clone {
     warp::filters::cookie::cookie(JWT_COOKIE_NAME).and_then(|cookie: String| async move {
         get_claims(&cookie).map_err(|_| NoAuth::rejection())

--- a/backend/api/crates/server/src/cors.rs
+++ b/backend/api/crates/server/src/cors.rs
@@ -1,6 +1,6 @@
-use warp::http::Method;
-use core::settings::SETTINGS;
 use config::CORS_ORIGINS;
+use core::settings::SETTINGS;
+use warp::http::Method;
 
 pub fn get_cors() -> warp::filters::cors::Builder {
     let builder = warp::cors()
@@ -11,6 +11,6 @@ pub fn get_cors() -> warp::filters::cors::Builder {
     if SETTINGS.get().unwrap().local_insecure {
         builder.allow_any_origin()
     } else {
-        builder.allow_origins(CORS_ORIGINS.into_iter().map(|x| x.clone()).clone())
+        builder.allow_origins(CORS_ORIGINS.iter().cloned())
     }
 }

--- a/backend/api/crates/server/src/db.rs
+++ b/backend/api/crates/server/src/db.rs
@@ -1,12 +1,16 @@
-use sqlx::postgres::{PgPool, PgPoolOptions, PgConnectOptions};
+use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions};
 
-use core::settings::{DbTarget, DbEndpoint, Settings};
 use config::DB_POOL_CONNECTIONS;
+use core::settings::{DbEndpoint, DbTarget, Settings};
 
-pub async fn get_pool(settings:&Settings) -> PgPool {
+pub async fn get_pool(settings: &Settings) -> PgPool {
     //let db_connection_string = &settings.db_credentials.to_string();
     let db_target = settings.db_target;
-    let n_connections = if db_target == DbTarget::Local || db_target == DbTarget::Proxy { 1 } else { DB_POOL_CONNECTIONS };
+    let n_connections = if db_target == DbTarget::Local || db_target == DbTarget::Proxy {
+        1
+    } else {
+        DB_POOL_CONNECTIONS
+    };
 
     let credentials = &settings.db_credentials;
 
@@ -16,12 +20,8 @@ pub async fn get_pool(settings:&Settings) -> PgPool {
         .database(&credentials.dbname);
 
     let connect_options = match &credentials.endpoint {
-        DbEndpoint::Tcp(host, port) => {
-            connect_options.host(host).port(*port)
-        },
-        DbEndpoint::Socket(path) => {
-            connect_options.socket(path)
-        }
+        DbEndpoint::Tcp(host, port) => connect_options.host(host).port(*port),
+        DbEndpoint::Socket(path) => connect_options.socket(path),
     };
 
     PgPoolOptions::new()
@@ -29,6 +29,4 @@ pub async fn get_pool(settings:&Settings) -> PgPool {
         .connect_with(connect_options)
         .await
         .expect("Postgres connection pool could not be created (local)")
-
-
 }

--- a/backend/api/crates/server/src/endpoints/user.rs
+++ b/backend/api/crates/server/src/endpoints/user.rs
@@ -1,35 +1,38 @@
-use actions::user::{get_profile, get_by_id, get_by_email, register};
-use shared::{
-    auth::{AuthClaims, RegisterRequest, RegisterError, SingleSignOnSuccess},
-    user::NoSuchUserError,
-    api::{
-        result::ResultResponse,
-        endpoints::{
-            ApiEndpoint,
-            user::{Profile, SingleSignOn},
-        }
-    }
-};
-use core::settings::SETTINGS;
 use crate::{
-    reply::HandlerResult,
     auth::reply_signin_auth,
-    reject::{CustomWarpRejection, InternalError, DbQueryError}
+    reject::{CustomWarpRejection, DbQueryError, InternalError},
+    reply::HandlerResult,
+};
+use actions::user::{get_by_email, get_by_id, get_profile, register};
+use core::settings::SETTINGS;
+use jsonwebtoken as jwt;
+use shared::{
+    api::{
+        endpoints::{
+            user::{Profile, SingleSignOn},
+            ApiEndpoint,
+        },
+        result::ResultResponse,
+    },
+    auth::{AuthClaims, RegisterError, RegisterRequest, SingleSignOnSuccess},
+    user::NoSuchUserError,
 };
 use sqlx::postgres::PgPool;
-use jsonwebtoken as jwt;
 
-pub async fn handle_get_profile(claims:AuthClaims, db:PgPool) -> HandlerResult< <Profile as ApiEndpoint>::Res, <Profile as ApiEndpoint>::Err> {
-
+pub async fn handle_get_profile(
+    claims: AuthClaims,
+    db: PgPool,
+) -> HandlerResult<<Profile as ApiEndpoint>::Res, <Profile as ApiEndpoint>::Err> {
     Ok(get_profile(&db, &claims.id).await)
 }
 
 //register handler doesn't use the usual wrapper since it needs to set the header
-pub async fn handle_register(user_id:String, req:RegisterRequest, db:PgPool) -> Result<impl warp::Reply, warp::Rejection> {
-
-
-
-    let err:Option<RegisterError> = {
+pub async fn handle_register(
+    user_id: String,
+    req: RegisterRequest,
+    db: PgPool,
+) -> Result<impl warp::Reply, warp::Rejection> {
+    let err: Option<RegisterError> = {
         if get_by_id(&db, &user_id).await.is_some() {
             Some(RegisterError::TakenId)
         } else if req.display_name.is_empty() {
@@ -55,9 +58,8 @@ pub async fn handle_register(user_id:String, req:RegisterRequest, db:PgPool) -> 
             //placeholder for now until we can really have empty WithHeader
             let reply = warp::reply::with_header(reply, "foo", "bar");
             Ok(reply)
-        },
+        }
         None => {
-
             register(&db, &user_id, &req)
                 .await
                 .map_err(|_| DbQueryError::rejection())?;
@@ -70,17 +72,20 @@ pub async fn handle_register(user_id:String, req:RegisterRequest, db:PgPool) -> 
 //the user_id is already validated in terms of firebase auth
 //now we need to check with the database
 //login handler doesn't use the usual wrapper since it needs to set the header
-pub async fn handle_signin_credentials(user_id:String, db:PgPool) -> Result<impl warp::Reply, warp::Rejection> {
-
+pub async fn handle_signin_credentials(
+    user_id: String,
+    db: PgPool,
+) -> Result<impl warp::Reply, warp::Rejection> {
     log::info!("Firebase is valid! user id is: {}", user_id);
-
 
     match get_by_id(&db, &user_id).await {
         Some(user) => reply_signin_auth(user_id, user.roles, false),
         None => {
             log::info!("hmm couldn't get user by id {}", user_id);
             //Since the happy path is a WithHeader reply, need wrap the sad path too
-            let reply = warp::reply::json(&ResultResponse::Err::<(), NoSuchUserError>(NoSuchUserError{}));
+            let reply = warp::reply::json(&ResultResponse::Err::<(), NoSuchUserError>(
+                NoSuchUserError {},
+            ));
             //TODO: https://github.com/seanmonstar/warp/issues/587#issuecomment-633961421
             //let reply = warp::reply::WithHeader { header: None, reply };
 
@@ -89,24 +94,27 @@ pub async fn handle_signin_credentials(user_id:String, db:PgPool) -> Result<impl
             Ok(reply)
         }
     }
-
-
 }
 
-
-//the claims are already validated from cookie and db lookup 
+//the claims are already validated from cookie and db lookup
 //no need to validate anything else
-pub async fn handle_get_sso_jwt(auth:AuthClaims) -> HandlerResult< <SingleSignOn as ApiEndpoint>::Res, <SingleSignOn as ApiEndpoint>::Err> {
-
+pub async fn handle_get_sso_jwt(
+    auth: AuthClaims,
+) -> HandlerResult<<SingleSignOn as ApiEndpoint>::Res, <SingleSignOn as ApiEndpoint>::Err> {
     log::info!("Firebase is valid! user id is: {}", auth.id);
 
     let claims = AuthClaims {
         id: auth.id,
         csrf: None,
-        roles: auth.roles
+        roles: auth.roles,
     };
 
-    let jwt = jwt::encode(&jwt::Header::default(), &claims, &SETTINGS.get().unwrap().jwt_encoding_key).map_err(|_| InternalError::rejection())?;
+    let jwt = jwt::encode(
+        &jwt::Header::default(),
+        &claims,
+        &SETTINGS.get().unwrap().jwt_encoding_key,
+    )
+    .map_err(|_| InternalError::rejection())?;
 
-    Ok(Ok(SingleSignOnSuccess{jwt}))
+    Ok(Ok(SingleSignOnSuccess { jwt }))
 }

--- a/backend/api/crates/server/src/endpoints/user.rs
+++ b/backend/api/crates/server/src/endpoints/user.rs
@@ -32,20 +32,18 @@ pub async fn handle_register(
     req: RegisterRequest,
     db: PgPool,
 ) -> Result<impl warp::Reply, warp::Rejection> {
-    let err: Option<RegisterError> = {
-        if get_by_id(&db, &user_id).await.is_some() {
-            Some(RegisterError::TakenId)
-        } else if req.display_name.is_empty() {
-            Some(RegisterError::EmptyDisplayname)
-        } else if req.first_name.is_empty() {
-            Some(RegisterError::EmptyFirstname)
-        } else if req.last_name.is_empty() {
-            Some(RegisterError::EmptyLastname)
-        } else if get_by_email(&db, &req.email).await.is_some() {
-            Some(RegisterError::TakenEmail)
-        } else {
-            None
-        }
+    let err: Option<RegisterError> = if get_by_id(&db, &user_id).await.is_some() {
+        Some(RegisterError::TakenId)
+    } else if req.display_name.is_empty() {
+        Some(RegisterError::EmptyDisplayname)
+    } else if req.first_name.is_empty() {
+        Some(RegisterError::EmptyFirstname)
+    } else if req.last_name.is_empty() {
+        Some(RegisterError::EmptyLastname)
+    } else if get_by_email(&db, &req.email).await.is_some() {
+        Some(RegisterError::TakenEmail)
+    } else {
+        None
     };
 
     match err {

--- a/backend/api/crates/server/src/lib.rs
+++ b/backend/api/crates/server/src/lib.rs
@@ -30,9 +30,6 @@ cfg_if! {
             hyper:: {
                 self,
                 Server,
-                Body,
-                Request,
-                Response
             },
         };
 

--- a/backend/api/crates/server/src/logger.rs
+++ b/backend/api/crates/server/src/logger.rs
@@ -1,24 +1,23 @@
-use core::settings::SETTINGS;
-use simplelog::*;
 use cfg_if::cfg_if;
+use simplelog::*;
 
 cfg_if! {
     if #[cfg(feature = "local")] {
-        pub fn init_logger() { 
+        pub fn init_logger() {
             CombinedLogger::init(vec![
                 TermLogger::new(LevelFilter::Info, Config::default(), TerminalMode::Mixed),
                 //WriteLogger::new(LevelFilter::Info, Config::default(), File::create("my_rust_binary.log").unwrap()),
             ])
             .unwrap();
         }
-    } else { 
-        pub fn init_logger() { 
+    } else {
+        pub fn init_logger() {
             CombinedLogger::init(vec![
                 SimpleLogger::new(LevelFilter::Info, Config::default()),
                 //WriteLogger::new(LevelFilter::Info, Config::default(), File::create("my_rust_binary.log").unwrap()),
             ])
             .unwrap();
         }
-        
-    } 
+
+    }
 }

--- a/backend/api/crates/server/src/reply.rs
+++ b/backend/api/crates/server/src/reply.rs
@@ -12,7 +12,7 @@ impl<T: Serialize + DeserializeOwned, E: Serialize + DeserializeOwned> ReplyExt<
     for HandlerResult<T, E>
 {
     fn warp_reply(self) -> Result<warp::reply::Json, warp::reject::Rejection> {
-        self.and_then(|ok| ok.warp_reply())
+        self.and_then(ReplyExt::warp_reply)
     }
 }
 

--- a/backend/api/crates/server/src/reply.rs
+++ b/backend/api/crates/server/src/reply.rs
@@ -1,27 +1,28 @@
-use std::convert::Infallible;
-use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde::{de::DeserializeOwned, Serialize};
 use shared::api::result::ResultResponse;
 use warp::reject::Rejection;
 
-pub trait ReplyExt<T: Serialize + DeserializeOwned,E: Serialize + DeserializeOwned> {
+pub trait ReplyExt<T: Serialize + DeserializeOwned, E: Serialize + DeserializeOwned> {
     fn warp_reply(self) -> Result<warp::reply::Json, warp::reject::Rejection>;
 }
 
 pub type HandlerResult<T, E> = Result<Result<T, E>, Rejection>;
 
-impl <T: Serialize + DeserializeOwned,E: Serialize + DeserializeOwned> ReplyExt<T,E> for HandlerResult<T,E> { 
-
+impl<T: Serialize + DeserializeOwned, E: Serialize + DeserializeOwned> ReplyExt<T, E>
+    for HandlerResult<T, E>
+{
     fn warp_reply(self) -> Result<warp::reply::Json, warp::reject::Rejection> {
         self.and_then(|ok| ok.warp_reply())
     }
 }
 
-impl <T: Serialize + DeserializeOwned,E: Serialize + DeserializeOwned> ReplyExt<T,E> for Result<T,E> {
-
+impl<T: Serialize + DeserializeOwned, E: Serialize + DeserializeOwned> ReplyExt<T, E>
+    for Result<T, E>
+{
     fn warp_reply(self) -> Result<warp::reply::Json, warp::reject::Rejection> {
         match self {
             Self::Ok(value) => Ok(warp::reply::json(&ResultResponse::Ok::<T, E>(value))),
-            Self::Err(value) => Ok(warp::reply::json(&ResultResponse::Err::<T, E>(value)))
+            Self::Err(value) => Ok(warp::reply::json(&ResultResponse::Err::<T, E>(value))),
         }
     }
 }

--- a/backend/api/crates/server/src/utils.rs
+++ b/backend/api/crates/server/src/utils.rs
@@ -1,6 +1,5 @@
 // https://users.rust-lang.org/t/ownership-and-async-move-inside-a-loop/43250/5?u=dakom
 
-
 #[macro_export]
 macro_rules! async_clone_fn {
     ($($share:ident),*; |$($arg:ident),*| { $($tok:tt)* }) => {
@@ -15,7 +14,6 @@ macro_rules! async_clone_fn {
         }
     };
 }
-
 
 #[macro_export]
 macro_rules! async_clone_cb {

--- a/backend/api/main/src/logger.rs
+++ b/backend/api/main/src/logger.rs
@@ -1,23 +1,23 @@
-use simplelog::*;
 use cfg_if::cfg_if;
+use simplelog::*;
 
 cfg_if! {
     if #[cfg(feature = "local")] {
-        pub fn init_logger() { 
+        pub fn init_logger() {
             CombinedLogger::init(vec![
                 TermLogger::new(LevelFilter::Info, Config::default(), TerminalMode::Mixed),
                 //WriteLogger::new(LevelFilter::Info, Config::default(), File::create("my_rust_binary.log").unwrap()),
             ])
             .unwrap();
         }
-    } else { 
-        pub fn init_logger() { 
+    } else {
+        pub fn init_logger() {
             CombinedLogger::init(vec![
                 SimpleLogger::new(LevelFilter::Info, Config::default()),
                 //WriteLogger::new(LevelFilter::Info, Config::default(), File::create("my_rust_binary.log").unwrap()),
             ])
             .unwrap();
         }
-        
-    } 
+
+    }
 }

--- a/backend/api/main/src/main.rs
+++ b/backend/api/main/src/main.rs
@@ -1,9 +1,4 @@
-//see: https://github.com/rust-lang/cargo/issues/8010
-#![cfg_attr(feature = "quiet", allow(warnings))]
-
 mod logger;
-
-use dotenv::dotenv;
 
 #[tokio::main]
 async fn main() {

--- a/config/rust/src/lib.rs
+++ b/config/rust/src/lib.rs
@@ -1,16 +1,17 @@
-pub const MEDIA_UI_PATH:&'static str = "ui";
-pub const MAX_SIGNIN_COOKIE:&'static str = "1209600"; // 2 weeks
-pub const JSON_BODY_LIMIT:u64 = 16384; //1024 * 16
-pub const COOKIE_DOMAIN:&'static str = "jicloud.org";
-pub const CORS_ORIGINS:[&'static str;2] = ["https://jicloud.org", "https://sandbox.jicloud.org"];
-pub const DB_POOL_CONNECTIONS:u32 = 5;
+pub const MEDIA_UI_PATH: &str = "ui";
+pub const MAX_SIGNIN_COOKIE: &str = "1209600"; // 2 weeks
+pub const JSON_BODY_LIMIT: u64 = 1024 * 16; // 16
+pub const COOKIE_DOMAIN: &str = "jicloud.org";
+pub const CORS_ORIGINS: [&str; 2] = ["https://jicloud.org", "https://sandbox.jicloud.org"];
+pub const DB_POOL_CONNECTIONS: u32 = 5;
 
-pub const REMOTE_DB_USER:&'static str = "postgres";
-pub const REMOTE_DB_NAME:&'static str = "jicloud";
-pub const SQL_PROXY_PORT:u16 = 6432; //must match the port number in build-utils/package.json where cloud-sql-proxy is launched
+pub const REMOTE_DB_USER: &str = "postgres";
+pub const REMOTE_DB_NAME: &str = "jicloud";
+pub const SQL_PROXY_PORT: u16 = 6432; //must match the port number in build-utils/package.json where cloud-sql-proxy is launched
 
-pub const DB_INSTANCE_SANDBOX:&'static str = "ji-cloud-developer-sandbox:europe-west1:ji-cloud-003-sandbox";
-pub const DB_INSTANCE_RELEASE:&'static str = "ji-cloud:europe-west1:ji-cloud-002";
+pub const DB_INSTANCE_SANDBOX: &str =
+    "ji-cloud-developer-sandbox:europe-west1:ji-cloud-003-sandbox";
+pub const DB_INSTANCE_RELEASE: &str = "ji-cloud:europe-west1:ji-cloud-002";
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum RemoteTarget {
@@ -20,17 +21,17 @@ pub enum RemoteTarget {
 }
 
 impl RemoteTarget {
-	pub fn google_credentials_env_name(&self) -> &'static str {
+    pub fn google_credentials_env_name(&self) -> &'static str {
         match self {
             Self::Local => "GOOGLE_APPLICATION_CREDENTIALS_DEV_SANDBOX",
             Self::Sandbox => "GOOGLE_APPLICATION_CREDENTIALS_DEV_SANDBOX",
             Self::Release => "GOOGLE_APPLICATION_CREDENTIALS_DEV_RELEASE",
         }
     }
-	
+
     pub fn api_url(&self) -> &'static str {
         match self {
-            Self::Local => "http://localhost:8081", 
+            Self::Local => "http://localhost:8081",
             Self::Sandbox => "https://api.sandbox.jicloud.org",
             Self::Release => "https://api.jicloud.org",
         }
@@ -38,7 +39,7 @@ impl RemoteTarget {
 
     pub fn api_js_url(&self) -> &'static str {
         match self {
-            Self::Local => "http://localhost:8082", 
+            Self::Local => "http://localhost:8082",
             Self::Sandbox => "https://api-js.sandbox.jicloud.org",
             Self::Release => "https://api-js.jicloud.org",
         }
@@ -46,27 +47,27 @@ impl RemoteTarget {
 
     pub fn media_url(&self) -> &'static str {
         match self {
-            Self::Local => "http://localhost:4102", 
+            Self::Local => "http://localhost:4102",
             Self::Sandbox | Self::Release => "https://media.jicloud.org",
         }
     }
 
-	pub fn pages_url(&self) -> &'static str {
+    pub fn pages_url(&self) -> &'static str {
         match self {
-            Self::Local => "http://localhost:8080", 
+            Self::Local => "http://localhost:8080",
             Self::Sandbox => "https://sandbox.jicloud.org",
             Self::Release => "https://jicloud.org",
         }
     }
-	
-	pub fn frontend_url(&self) -> &'static str {
+
+    pub fn frontend_url(&self) -> &'static str {
         match self {
             Self::Local | Self::Sandbox => "https://frontend.sandbox.jicloud.org",
             Self::Release => "https://frontend.jicloud.org",
         }
     }
 
-    pub fn spa_url(&self, app:&str, path:&str) -> String {
+    pub fn spa_url(&self, app: &str, path: &str) -> String {
         format!("{}/{}/{}", self.frontend_url(), app, path)
     }
 
@@ -74,7 +75,8 @@ impl RemoteTarget {
         None
     }
 
-    pub fn replace_media_ui<S: AsRef<str>>(&self, s:S) -> String {
-        s.as_ref().replace("%MEDIA_UI%", &format!("{}/ui", self.media_url()))
+    pub fn replace_media_ui<S: AsRef<str>>(&self, s: S) -> String {
+        s.as_ref()
+            .replace("%MEDIA_UI%", &format!("{}/ui", self.media_url()))
     }
 }

--- a/shared/rust/src/api/endpoints.rs
+++ b/shared/rust/src/api/endpoints.rs
@@ -1,6 +1,4 @@
 use serde::{de::DeserializeOwned, Serialize};
-use super::result::ResultResponse;
-
 
 pub trait ApiEndpoint {
     type Req: Serialize;
@@ -12,38 +10,37 @@ pub mod user {
     use super::ApiEndpoint;
 
     use crate::{
-        auth::{SigninSuccess, RegisterRequest, RegisterSuccess, RegisterError, SingleSignOnSuccess},
-        user::{UserRole, User, NoSuchUserError},
+        auth::{
+            RegisterError, RegisterRequest, RegisterSuccess, SigninSuccess, SingleSignOnSuccess,
+        },
+        user::{NoSuchUserError, User},
     };
 
-    pub struct Signin { }
+    pub struct Signin {}
     impl ApiEndpoint for Signin {
         type Req = ();
         type Res = SigninSuccess;
         type Err = NoSuchUserError;
     }
 
-
-    pub struct SingleSignOn { }
+    pub struct SingleSignOn {}
     impl ApiEndpoint for SingleSignOn {
         type Req = ();
         type Res = SingleSignOnSuccess;
         type Err = ();
     }
 
-
-    pub struct Register { }
+    pub struct Register {}
     impl ApiEndpoint for Register {
         type Req = RegisterRequest;
         type Res = RegisterSuccess;
         type Err = RegisterError;
     }
 
-    pub struct Profile { }
+    pub struct Profile {}
     impl ApiEndpoint for Profile {
         type Req = ();
         type Res = User;
         type Err = NoSuchUserError;
     }
 }
-

--- a/shared/rust/src/api/mod.rs
+++ b/shared/rust/src/api/mod.rs
@@ -1,2 +1,2 @@
-pub mod result;
 pub mod endpoints;
+pub mod result;

--- a/shared/rust/src/api/result.rs
+++ b/shared/rust/src/api/result.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct HttpStatus {
@@ -8,24 +8,29 @@ pub struct HttpStatus {
 
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "type", content = "content", rename_all = "lowercase")]
-pub enum ResultResponse<T: Serialize + DeserializeOwned, E: Serialize + DeserializeOwned>{
+pub enum ResultResponse<T: Serialize + DeserializeOwned, E: Serialize + DeserializeOwned> {
     #[serde(deserialize_with = "T::deserialize")]
     Ok(T),
     #[serde(deserialize_with = "E::deserialize")]
-    Err(E)
+    Err(E),
 }
 
-impl <T: Serialize + DeserializeOwned, E: Serialize + DeserializeOwned> ResultResponse<T, E> {
+impl<T: Serialize + DeserializeOwned, E: Serialize + DeserializeOwned> ResultResponse<T, E> {
     pub fn unwrap(self) -> T {
         match self {
             ResultResponse::Ok(x) => x,
-            ResultResponse::Err(x) => panic!("Could not unwrap ResultResponse. Error: [{}]", serde_json::to_string(&x).unwrap()),
+            ResultResponse::Err(x) => panic!(
+                "Could not unwrap ResultResponse. Error: [{}]",
+                serde_json::to_string(&x).unwrap()
+            ),
         }
     }
 }
 
-impl <T: Serialize + DeserializeOwned,E: Serialize + DeserializeOwned> From<ResultResponse<T,E>> for Result<T,E> {
-    fn from(resp:ResultResponse<T, E>) -> Result<T,E> {
+impl<T: Serialize + DeserializeOwned, E: Serialize + DeserializeOwned> From<ResultResponse<T, E>>
+    for Result<T, E>
+{
+    fn from(resp: ResultResponse<T, E>) -> Result<T, E> {
         match resp {
             ResultResponse::Ok(x) => Result::Ok(x),
             ResultResponse::Err(x) => Result::Err(x),
@@ -33,8 +38,10 @@ impl <T: Serialize + DeserializeOwned,E: Serialize + DeserializeOwned> From<Resu
     }
 }
 
-impl <T: Serialize + DeserializeOwned,E: Serialize + DeserializeOwned> From<Result<T,E>> for ResultResponse<T,E> {
-    fn from(res:Result<T, E>) -> ResultResponse<T,E> {
+impl<T: Serialize + DeserializeOwned, E: Serialize + DeserializeOwned> From<Result<T, E>>
+    for ResultResponse<T, E>
+{
+    fn from(res: Result<T, E>) -> ResultResponse<T, E> {
         match res {
             Result::Ok(x) => ResultResponse::Ok(x),
             Result::Err(x) => ResultResponse::Err(x),

--- a/shared/rust/src/auth.rs
+++ b/shared/rust/src/auth.rs
@@ -1,17 +1,17 @@
-use serde::{Deserialize, Serialize};
 use crate::user::UserRole;
+use serde::{Deserialize, Serialize};
 
-pub const JWT_COOKIE_NAME:&'static str = "X-JWT";
-pub const CSRF_HEADER_NAME:&'static str = "X-CSRF";
+pub const JWT_COOKIE_NAME: &'static str = "X-JWT";
+pub const CSRF_HEADER_NAME: &str = "X-CSRF";
 
 #[derive(Serialize, Deserialize)]
 pub struct SigninSuccess {
-    pub csrf: String
+    pub csrf: String,
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct SingleSignOnSuccess {
-    pub jwt: String
+    pub jwt: String,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/shared/rust/src/lib.rs
+++ b/shared/rust/src/lib.rs
@@ -1,3 +1,3 @@
-pub mod user;
-pub mod auth;
 pub mod api;
+pub mod auth;
+pub mod user;

--- a/shared/rust/src/user.rs
+++ b/shared/rust/src/user.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use serde_repr::{Serialize_repr, Deserialize_repr};
+use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[derive(Serialize_repr, Deserialize_repr, PartialEq, Debug, Clone)]
 #[repr(u8)]
@@ -8,7 +8,7 @@ pub enum UserRole {
 }
 
 impl From<i32> for UserRole {
-    fn from(x:i32) -> Self {
+    fn from(x: i32) -> Self {
         if x == UserRole::Admin as i32 {
             UserRole::Admin
         } else {
@@ -16,7 +16,6 @@ impl From<i32> for UserRole {
         }
     }
 }
-
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct User {


### PR DESCRIPTION
run `cargo fmt` and clean up warnings, mostly of the backend / shared code